### PR TITLE
Bugfix for get_airport_delays and get_top_destinations functions

### DIFF
--- a/01-plumber_basics/05-all_functions.R
+++ b/01-plumber_basics/05-all_functions.R
@@ -35,7 +35,7 @@ get_airport_delays <- function(min_flights = 200) {
 get_daily_volume <- function(origin = NULL) {
   data <- flights
   if (!is.null(origin)) {
-    data <- filter(data, origin == origin)
+    data <- filter(data, origin == {{ origin }})
   }
 
   data |>
@@ -50,7 +50,7 @@ get_daily_volume <- function(origin = NULL) {
 # 4. Top destination airports from an origin
 get_top_destinations <- function(origin = "JFK", top_n = 5) {
   flights |>
-    filter(origin == origin) |>
+    filter(origin == {{ origin }}) |>
     count(dest, sort = TRUE) |>
     top_n(top_n, wt = n) |>
     left_join(airports, by = c("dest" = "faa")) |>

--- a/01-plumber_basics/analysis.R
+++ b/01-plumber_basics/analysis.R
@@ -35,7 +35,7 @@ get_airport_delays <- function(min_flights = 200) {
 get_daily_volume <- function(origin = NULL) {
   data <- flights
   if (!is.null(origin)) {
-    data <- filter(data, origin == origin)
+    data <- filter(data, origin == {{ origin }})
   }
 
   data |>
@@ -50,7 +50,7 @@ get_daily_volume <- function(origin = NULL) {
 # 4. Top destination airports from an origin
 get_top_destinations <- function(origin = "JFK", top_n = 5) {
   flights |>
-    filter(origin == origin) |>
+    filter(origin == {{ origin }}) |>
     count(dest, sort = TRUE) |>
     top_n(top_n, wt = n) |>
     left_join(airports, by = c("dest" = "faa")) |>


### PR DESCRIPTION
Hi,

Thanks for the workshop yesterday. It was really interesting and useful.
While playing with the examples, I noticed that a couple of the functions don't work as I think they are intended to. It's nothing to do with the plumber stuff, so it doesn't affect the message of the workshop, but I thought I would submit the fixes.

In `get_airport_delays` and `get_top_destinations` you have a line to filter the `flights` data to the origin airport.
```
filter(origin == origin)
```
Because `filter` uses data masking, both instances of `origin` are taken to refer to the `origin` column in the data. The `origin` column equals the `origin` column for all rows in the data, so the same rows are returned no matter what the supplied `origin` parameter is.
As detailed in the [`dplyr` manual](https://dplyr.tidyverse.org/articles/programming.html#indirection), you need to put the second origin in double braces to make it clear that it is an env-variable.
```
filter(origin == {{ origin }})
```

I've made the change in both `05-all_functions.R` and `analysis.R`

Thanks again for the workshop
Richard